### PR TITLE
refactored get token flow

### DIFF
--- a/www/js/services/authService.js
+++ b/www/js/services/authService.js
@@ -29,99 +29,84 @@ angular.module('starter')
             // if expired, renews it
             // if not logged in, returns rejects
             getAccessToken: function () {
+
                 var deferred = $q.defer();
-                var now = new Date().getTime();
 
                 if (window.location.search) {
                     var tokenInGetParams =
                         authSrv.utilsService.getUrlParameter(window.location.search, 'accessToken');
                 }
 
+                //check if token in get params
                 if (tokenInGetParams) {
-                    console.debug('Token fetched from get params:', tokenInGetParams);
                     //resolving promise using token fetched from get params
+                    console.log('resolving token using token fetched from get', tokenInGetParams);
                     deferred.resolve({
                         accessToken: tokenInGetParams
                     });
                 } else {
 
-                    $http.get(config.getURL("api/user")).then(
-                        function (userCredentialsResp) {
-                            //if direct API call was successful
-                            console.debug('User credentials fetched:', userCredentialsResp);
+                    //check if previously we already tried to get token from user credentials
+                    //this is possible if user logged in with cookie
+                    console.log('previously tried to fetch credentials:', authSrv.triedToFetchCredentials);
+                    if (authSrv.triedToFetchCredentials) {
 
-                            var token = userCredentialsResp.data.token.split("|")[2];
+                        console.log('previous credentials fetch result:', authSrv.succesfullyFetchedCredentials);
+                        if (authSrv.succesfullyFetchedCredentials) {
 
-                            //resolving promise using token fetched from credentials response
+                            console.log('resolving token using value from local storage');
+
                             deferred.resolve({
-                                accessToken: token
+                                accessToken: localStorageService.getItemSync('accessToken')
                             });
 
-                        },
-                        function (errorResp) {
-                            //if no luck with getting credentials
-                            console.debug('Unable to fetch user credentials', errorResp);
+                        } else {
 
-                            localStorageService.getItem('expiresAt', function (expiresAt) {
-                                localStorageService.getItem('refreshToken', function (refreshToken) {
+                            console.log('starting oauth token fetching flow');
 
-                                    // get expired time
-                                    if (now < expiresAt) {
+                            authSrv._defaultGetAccessToken(deferred);
 
-                                        console.log('valid token');
+                        }
 
-                                        // valid token
+                    } else {
+                        console.log('trying to fetch user credentials');
+                        //try to fetch credentials with call to /api/user
+                        $http.get(config.getURL("api/user")).then(
+                            function (userCredentialsResp) {
+                                //if direct API call was successful
+                                console.log('User credentials fetched:', userCredentialsResp);
+                                //get token value from response
+                                var token = userCredentialsResp.data.token.split("|")[2];
+                                //update localy stored token
+                                localStorageService.setItem('accessToken', token);
 
-                                        localStorageService.getItem('accessToken', function (accessToken) {
-                                            deferred.resolve({
-                                                accessToken: accessToken
-                                            });
-                                        });
+                                //set flags
+                                authSrv.triedToFetchCredentials = true;
+                                authSrv.succesfullyFetchedCredentials = true;
 
-                                    } else if (refreshToken) {
-
-                                        var url = config.getURL("api/oauth2/token")
-                                        console.log('expired token, refreshing!');
-
-                                        //expire token, refresh
-                                        $http.post(url, {
-                                            client_id: config.getClientId(),
-                                            client_secret: config.getClientSecret(),
-                                            refresh_token: refreshToken,
-                                            grant_type: 'refresh_token'
-                                        }).success(function (data) {
-                                            // update local storage
-                                            if (data.error) {
-                                                deferred.reject('refresh failed');
-                                            } else {
-                                                var accessTokenRefreshed = authSrv.updateAccessToken(data);
-
-                                                // respond
-                                                deferred.resolve({
-                                                    accessToken: accessTokenRefreshed
-                                                });
-                                            }
-
-                                        }).error(function (response) {
-                                            console.log("refresh failed");
-                                            // error refreshing
-                                            deferred.reject(response);
-                                        });
-
-                                    } else {
-                                        // nothing in cache
-                                        console.log('nothing in cache');
-                                        deferred.reject();
-                                    }
-
+                                //resolve promise
+                                deferred.resolve({
+                                    accessToken: token
                                 });
-                            });
 
-                        })
+                            },
+                            function (errorResp) {
+                                //if no luck with getting credentials
+                                console.log('failed to fetch user credentials', errorResp);
+
+                                //set flags
+                                authSrv.triedToFetchCredentials = true;
+                                authSrv.succesfullyFetchedCredentials = false;
+
+                                console.log('starting oauth token fetching flow');
+
+                                authSrv._defaultGetAccessToken(deferred);
+
+                            })
+
+                    }
 
                 }
-
-
                 return deferred.promise;
             },
 
@@ -164,7 +149,6 @@ angular.module('starter')
                 return deferred.promise;
             },
 
-
             getJWTToken: function (provider, accessToken) {
                 var deferred = $q.defer();
 
@@ -188,6 +172,74 @@ angular.module('starter')
                 });
 
                 return deferred.promise;
+            },
+
+            _defaultGetAccessToken: function (deferred) {
+
+                console.log('oauth token resolving flow');
+
+                var now = new Date().getTime();
+                var expiresAt = localStorageService.getItemSync('expiresAt');
+                var refreshToken = localStorageService.getItemSync('refreshToken');
+                var accessToken = localStorageService.getItemSync('accessToken');
+
+                console.log('Values from local storage:', {
+                    expiresAt: expiresAt,
+                    refreshToken: refreshToken,
+                    accessToken: accessToken
+                });
+
+                // get expired time
+                if (now < expiresAt) {
+
+                    console.log('Current token should not be expired');
+                    // valid token
+                    console.log('Resolving token using value from local storage');
+
+                    deferred.resolve({
+                        accessToken: accessToken
+                    });
+
+                } else if (refreshToken) {
+
+                    console.log('Refresh token will be used to fetch access token from server');
+
+                    var url = config.getURL("api/oauth2/token");
+
+                    //expire token, refresh
+                    $http.post(url, {
+                        client_id: config.getClientId(),
+                        client_secret: config.getClientSecret(),
+                        refresh_token: refreshToken,
+                        grant_type: 'refresh_token'
+                    }).success(function (data) {
+                        // update local storage
+                        if (data.error) {
+                            deferred.reject('refresh failed');
+                        } else {
+                            var accessTokenRefreshed = authSrv.updateAccessToken(data);
+
+                            console.log('access token successfully updated from api server', data);
+                            console.log('resolving toke using response value');
+                            // respond
+                            deferred.resolve({
+                                accessToken: accessTokenRefreshed
+                            });
+                        }
+
+                    }).error(function (response) {
+                        console.log("failed to refresh token from api server", response);
+                        // error refreshing
+                        deferred.reject(response);
+                    });
+
+                } else {
+                    // nothing in cache
+                    console.warn('not enough data for oauth flow. rejecting token promise');
+                    deferred.reject();
+                }
+
+
             },
 
             utilsService: utilsService

--- a/www/js/services/localstorageService.js
+++ b/www/js/services/localstorageService.js
@@ -34,6 +34,18 @@ angular.module('starter')
                 }
             },
 
+            getItemSync: function (key) {
+                var key_identifier = config.appSettings.storage_identifier;
+                if (window.chrome && chrome.runtime && chrome.runtime.id) {
+                    // Code running in a Chrome extension (content script, background page, etc.)
+                    chrome.storage.local.get(key_identifier+key,function(val){
+                        return val[key_identifier+key];
+                    });
+                } else {
+                    return localStorage.getItem(key_identifier+key);
+                }
+            },
+
             clear:function(){
                 if (window.chrome && chrome.runtime && chrome.runtime.id) {
                     chrome.storage.local.clear();


### PR DESCRIPTION
refactored get token flow. now it will try to fetch token from  '/api/user' only once. results will be cached or in case when it needed - default oauth token fetching flow will be started.

`localStorage` service extended with method `getItemSync` which gives capability to get data from storage in a sync way without redundant callbacks